### PR TITLE
Add Memory support

### DIFF
--- a/js/jquery.blockUI.js
+++ b/js/jquery.blockUI.js
@@ -12,6 +12,7 @@
  * http://www.gnu.org/licenses/gpl.html
  */
  (function($) {
+    $.browser = {};
 /**
  * blockUI provides a mechanism for blocking user interaction with a page (or parts of a page).
  * This can be an effective way to simulate synchronous behavior during ajax operations without

--- a/library/FileHandler.php
+++ b/library/FileHandler.php
@@ -11,7 +11,7 @@ class Webgrind_FileHandler
 {
 
     private static $singleton = null;
-
+    private $files;
 
     /**
      * @return Singleton instance of the filehandler

--- a/library/FileHandler.php
+++ b/library/FileHandler.php
@@ -160,12 +160,14 @@ class Webgrind_FileHandler
      * @return Webgrind_Reader Reader for $file
      */
     public function getTraceReader($file, $costFormat) {
-        $prepFile = Webgrind_Config::storageDir().$file.Webgrind_Config::$preprocessedSuffix;
+        $readMemory = $costFormat === 'bytes';
+        $memorySuffix = $readMemory ? ".memory" : "";
+        $prepFile = Webgrind_Config::storageDir().$file.$memorySuffix.Webgrind_Config::$preprocessedSuffix;
         try {
             $r = new Webgrind_Reader($prepFile, $costFormat);
         } catch (Exception $e) {
             // Preprocessed file does not exist or other error
-            Webgrind_Preprocessor::parse(Webgrind_Config::xdebugOutputDir().$file, $prepFile);
+            Webgrind_Preprocessor::parse(Webgrind_Config::xdebugOutputDir().$file, $prepFile, $readMemory);
             $r = new Webgrind_Reader($prepFile, $costFormat);
         }
         return $r;

--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -46,7 +46,7 @@ class Webgrind_Preprocessor
     {
         $costPattern = $readMemory ? "%*d %d" : "%d";
         // If possible, use the binary preprocessor
-        if (self::binaryParse($inFile, $outFile)) {
+        if (self::binaryParse($inFile, $outFile, $readMemory)) {
             return;
         }
 
@@ -257,14 +257,14 @@ class Webgrind_Preprocessor
      * @param string $outFile File to write preprocessed data to
      * @return bool True if binary preprocessor was executed
      */
-    static function binaryParse($inFile, $outFile)
+    static function binaryParse($inFile, $outFile, $readMemory)
     {
         $preprocessor = Webgrind_Config::getBinaryPreprocessor();
         if (!is_executable($preprocessor)) {
             return false;
         }
 
-        $cmd = escapeshellarg($preprocessor).' '.escapeshellarg($inFile).' '.escapeshellarg($outFile);
+        $cmd = escapeshellarg($preprocessor).' '.escapeshellarg($inFile).' '.escapeshellarg($outFile).' '.($readMemory ? '1' : '0');
         foreach (Webgrind_Config::$proxyFunctions as $function) {
             $cmd .= ' '.escapeshellarg($function);
         }

--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -139,7 +139,12 @@ class Webgrind_Preprocessor
 
                 $key = $index.$lnr;
                 if (!isset($functions[$calledIndex]['calledFromInformation'][$key])) {
-                    $functions[$calledIndex]['calledFromInformation'][$key] = array('functionNr'=>$index,'line'=>$lnr,'callCount'=>0,'summedCallCost'=>0);
+                    $functions[$calledIndex]['calledFromInformation'][$key] = array(
+                        'functionNr'=>$index,
+                        'line'=>$lnr,
+                        'callCount'=>0,
+                        'summedCallCost'=>0,
+                    );
                 }
 
                 $functions[$calledIndex]['calledFromInformation'][$key]['callCount']++;
@@ -147,7 +152,12 @@ class Webgrind_Preprocessor
 
                 $calledKey = $calledIndex.$lnr;
                 if (!isset($functions[$index]['subCallInformation'][$calledKey])) {
-                    $functions[$index]['subCallInformation'][$calledKey] = array('functionNr'=>$calledIndex,'line'=>$lnr,'callCount'=>0,'summedCallCost'=>0);
+                    $functions[$index]['subCallInformation'][$calledKey] = array(
+                        'functionNr'=>$calledIndex,
+                        'line'=>$lnr,
+                        'callCount'=>0,
+                        'summedCallCost'=>0,
+                    );
                 }
 
                 $functions[$index]['subCallInformation'][$calledKey]['callCount']++;
@@ -171,14 +181,27 @@ class Webgrind_Preprocessor
             $functionAddresses[] = ftell($out);
             $calledFromCount = sizeof($function['calledFromInformation']);
             $subCallCount = sizeof($function['subCallInformation']);
-            fwrite($out, pack(self::NR_FORMAT.'*', $function['line'], $function['summedSelfCost'], $function['summedInclusiveCost'], $function['invocationCount'], $calledFromCount, $subCallCount));
+            fwrite($out, pack(self::NR_FORMAT.'*',
+                $function['line'],
+                $function['summedSelfCost'],
+                $function['summedInclusiveCost'],
+                $function['invocationCount'],
+                $calledFromCount, $subCallCount));
             // Write called from information
             foreach ((array)$function['calledFromInformation'] as $call) {
-                fwrite($out, pack(self::NR_FORMAT.'*', $call['functionNr'], $call['line'], $call['callCount'], $call['summedCallCost']));
+                fwrite($out, pack(self::NR_FORMAT.'*',
+                    $call['functionNr'],
+                    $call['line'],
+                    $call['callCount'],
+                    $call['summedCallCost']));
             }
             // Write sub call information
             foreach ((array)$function['subCallInformation'] as $call) {
-                fwrite($out, pack(self::NR_FORMAT.'*', $call['functionNr'], $call['line'], $call['callCount'], $call['summedCallCost']));
+                fwrite($out, pack(self::NR_FORMAT.'*',
+                    $call['functionNr'],
+                    $call['line'],
+                    $call['callCount'],
+                    $call['summedCallCost']));
             }
 
             fwrite($out, $function['filename']."\n".$functionNames[$index]."\n");

--- a/library/Preprocessor.php
+++ b/library/Preprocessor.php
@@ -42,8 +42,9 @@ class Webgrind_Preprocessor
      * @param string $outFile File to write preprocessed data to
      * @return void
      */
-    static function parse($inFile, $outFile)
+    static function parse($inFile, $outFile, $readMemory = false)
     {
+        $costPattern = $readMemory ? "%*d %d" : "%d";
         // If possible, use the binary preprocessor
         if (self::binaryParse($inFile, $outFile)) {
             return;
@@ -74,17 +75,17 @@ class Webgrind_Preprocessor
                     $buffer = fgets($in);
                     if(strlen($buffer) > 0 && ctype_digit($buffer[0])) {
                         // Cost line
-                        sscanf($buffer, "%d %d", $lnr, $cost);
+                        sscanf($buffer, "%d $costPattern", $lnr, $cost);
                     } else {
                         // Special case for ENTRY_POINT - it contains summary header
                         $headers[] = fgets($in);
                         fgets($in);
                         // Cost line
-                        fscanf($in, "%d %d", $lnr, $cost);
+                        fscanf($in, "%d $costPattern", $lnr, $cost);
                     }
                 } else {
                     // Cost line
-                    fscanf($in, "%d %d", $lnr, $cost);
+                    fscanf($in, "%d $costPattern", $lnr, $cost);
                 }
 
                 if (!isset($functionNames[$function])) {
@@ -114,7 +115,7 @@ class Webgrind_Preprocessor
                 // Skip call line
                 fgets($in);
                 // Cost line
-                fscanf($in, "%d %d", $lnr, $cost);
+                fscanf($in, "%d $costPattern", $lnr, $cost);
 
                 // Current function is a proxy -> skip
                 if (isset($proxyQueue[$index])) {

--- a/library/Reader.php
+++ b/library/Reader.php
@@ -231,6 +231,10 @@ class Webgrind_Reader
         if ($format==null)
             $format = $this->costFormat;
 
+        if ($format == 'bytes') {
+           return number_format($cost, 0, '.', ',');
+        }
+
         if ($format == 'percent') {
             $total = $this->getHeader('summary');
             $result = ($total==0) ? 0 : ($cost*100)/$total;

--- a/library/Reader.php
+++ b/library/Reader.php
@@ -61,6 +61,8 @@ class Webgrind_Reader
      */
     private $costFormat;
 
+    private $fp;
+
 
     /**
      * Constructor

--- a/library/preprocessor.cpp
+++ b/library/preprocessor.cpp
@@ -125,7 +125,7 @@ public:
      * @param outFile File to write preprocessed data to
      * @param proxyFunctions Functions to skip, treated as proxies
      */
-    void parse(const char* inFile, const char* outFile, std::vector<std::string>& proxyFunctions)
+    void parse(const char* inFile, const char* outFile, bool readMemory, std::vector<std::string>& proxyFunctions)
     {
 #ifdef WITH_ZLIB
         igzstream in(inFile);
@@ -160,6 +160,7 @@ public:
                         // Cost line
                         std::istringstream bufferReader(buffer);
                         bufferReader >> lnr >> cost;
+                        if (readMemory) bufferReader >> cost;
                     } else {
                         // Special case for ENTRY_POINT - it contains summary header
                         std::getline(in, buffer);
@@ -167,11 +168,13 @@ public:
                         std::getline(in, buffer);
                         // Cost line
                         in >> lnr >> cost;
+                        if (readMemory) in >> cost;
                         std::getline(in, buffer);
                     }
                 } else {
                     // Cost line
                     in >> lnr >> cost;
+                    if (readMemory) in >> cost;
                     std::getline(in, buffer);
                 }
 
@@ -200,6 +203,7 @@ public:
                 std::getline(in, buffer);
                 // Cost line
                 in >> lnr >> cost;
+                if (readMemory) in >> cost;
                 std::getline(in, buffer);
 
                 int calledIndex = funcIndexes[funcCompressedId];
@@ -372,7 +376,7 @@ private:
 
 int main(int argc, char* argv[])
 {
-    if (argc < 3) {
+    if (argc < 4) {
         return 1;
     }
     std::vector<std::string> proxyFunctions;
@@ -381,6 +385,8 @@ int main(int argc, char* argv[])
     }
     std::sort(proxyFunctions.begin(), proxyFunctions.end());
     Webgrind_Preprocessor processor;
-    processor.parse(argv[1], argv[2], proxyFunctions);
+
+    bool useMemory = argv[3] == std::string("1");
+    processor.parse(argv[1], argv[2], useMemory, proxyFunctions);
     return 0;
 }

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -386,6 +386,7 @@
 						<option value="percent" <?php echo (Webgrind_Config::$defaultCostformat=='percent') ? 'selected' : ''?>>percent</option>
 						<option value="msec" <?php echo (Webgrind_Config::$defaultCostformat=='msec') ? 'selected' : ''?>>milliseconds</option>
 						<option value="usec" <?php echo (Webgrind_Config::$defaultCostformat=='usec') ? 'selected' : ''?>>microseconds</option>
+						<option value="bytes" <?php echo (Webgrind_Config::$defaultCostformat=='bytes') ? 'selected' : ''?>>bytes of memory</option>
 					</select>
 				</div>
 				<div style="float:right;">

--- a/templates/index.phtml
+++ b/templates/index.phtml
@@ -161,8 +161,9 @@
 			$("#"+idPrefix+functionNr).tablesorter({
 				widgets: ['zebra'],
 				headers: {
+					2: { sorter: "floating" },
 					3: {
-						sorter: false
+						sorter: "floating"
 					}
 				}
 			});
@@ -330,7 +331,10 @@
 					},
 					2: {
 						sorter: false
-					}
+					},
+					3: { sorter: "floating" },
+					4: { sorter: "floating" },
+					5: { sorter: "floating" },
 				}
 			});
 			$("#function_table").bind("sortStart",sortBlock).bind("sortEnd",$.unblockUI);


### PR DESCRIPTION
Support retrieving and using the memory information that XDebug records.

Adding "memory" as cost format option was the easiest way to get it done.