### PR TITLE
Fixed paths to be compatible with php-fpm containers

### DIFF
--- a/config.php
+++ b/config.php
@@ -65,7 +65,7 @@ class Webgrind_Config extends Webgrind_MasterConfig {
      */
     static function exposeServerFile($file) {
         // Grant access to all files remapped under the `/host` directory.
-        //$prefix = '/host/';                                    /** DOCKER:ENABLE **/
+        //$prefix = '/'; #'/host/';                                    /** DOCKER:ENABLE **/
         //$file = realpath($prefix . $file);                     /** DOCKER:ENABLE **/
         //return strncmp($prefix, $file, strlen($prefix)) === 0  /** DOCKER:ENABLE **/
         //    ? $file                                            /** DOCKER:ENABLE **/


### PR DESCRIPTION
After connecting a php-fpm and webgrind container, webgrind cannot see php-fpm profiling.

Webgrind automatically filters out the webgrind application path `/var/ww/html`, but this identical to the php-fpm application path which is also `/var/www/html`

Others have modified FileManager.php but the better solution is to move the webgrind path as this allows one to view source code as well.